### PR TITLE
add gif compression

### DIFF
--- a/efb_wechat_slave/__init__.py
+++ b/efb_wechat_slave/__init__.py
@@ -6,7 +6,6 @@ import logging
 import tempfile
 import time
 import threading
-import subprocess
 from gettext import translation
 from json import JSONDecodeError
 from pathlib import Path

--- a/efb_wechat_slave/utils.py
+++ b/efb_wechat_slave/utils.py
@@ -245,9 +245,7 @@ if os.name == "nt":
             subprocess.run(["gifsicle", "--resize-method=catrom", "--lossy=100", "-O2", "-o", compress_file.name, file.name], check=True)
             new_file_size = os.path.getsize(compress_file.name)
             if new_file_size > 1024 * 1024:
-                scales = [600, 512, 480, 400, 360, 300, 256, 250, 200, 150, 100]
-                scales = [scale for scale in scales if scale < metadata['streams'][0]['width']]
-                scales = sorted(scales, reverse=True)
+                scales = [512, 480, 400, 360, 300, 256, 250, 200, 150, 100]
                 for scale in scales:
                     subprocess.run(["gifsicle", "--resize-method=catrom",  "--resize-fit", f"{scale}x{scale}", "--lossy=100", "-O2", "-o", compress_file.name, file.name], check=True)
                     new_file_size = os.path.getsize(compress_file.name)
@@ -271,9 +269,7 @@ else:
             subprocess.run(["gifsicle", "--resize-method=catrom", "--lossy=100", "-O2", "-o", compress_file.name, file.name], check=True)
             new_file_size = os.path.getsize(compress_file.name)
             if new_file_size > 1024 * 1024:
-                scales = [600, 512, 480, 400, 360, 300, 256, 250, 200, 150, 100]
-                scales = [scale for scale in scales if scale < metadata['streams'][0]['width']]
-                scales = sorted(scales, reverse=True)
+                scales = [512, 480, 400, 360, 300, 256, 250, 200, 150, 100]
                 for scale in scales:
                     subprocess.run(["gifsicle", "--resize-method=catrom",  "--resize-fit", f"{scale}x{scale}", "--lossy=100", "-O2", "-o", compress_file.name, file.name], check=True)
                     new_file_size = os.path.getsize(compress_file.name)

--- a/efb_wechat_slave/utils.py
+++ b/efb_wechat_slave/utils.py
@@ -3,14 +3,10 @@ import base64
 import io
 import os
 import subprocess
-import sys
 import json
-from shutil import copyfileobj
 from tempfile import NamedTemporaryFile
 from typing import Dict, Any, TYPE_CHECKING, List, IO
 
-import ffmpeg
-from ffmpeg._utils import convert_kwargs_to_cmd_line_args
 
 from ehforwarderbot.types import MessageID
 from .vendor.itchat import utils as itchat_utils

--- a/efb_wechat_slave/utils.py
+++ b/efb_wechat_slave/utils.py
@@ -2,8 +2,15 @@
 import base64
 import io
 import os
+import subprocess
+import sys
 import json
-from typing import Dict, Any, TYPE_CHECKING, List
+from shutil import copyfileobj
+from tempfile import NamedTemporaryFile
+from typing import Dict, Any, TYPE_CHECKING, List, IO
+
+import ffmpeg
+from ffmpeg._utils import convert_kwargs_to_cmd_line_args
 
 from ehforwarderbot.types import MessageID
 from .vendor.itchat import utils as itchat_utils
@@ -221,3 +228,153 @@ def imgcat(file: io.BytesIO, filename: str) -> str:
     res += base64.b64encode(file.getvalue()).decode()
     res += print_st()
     return res
+
+
+if os.name == "nt":
+    # Workaround for Windows which cannot open the same file as "read" twice.
+    # Using stdin/stdout pipe for IO with ffmpeg.
+    # Said to be only working with a few encodings. It seems that Telegram GIF
+    # (MP4, h264, soundless) luckily felt in that range.
+    #
+    # See: https://etm.1a23.studio/issues/90
+
+    def ffprobe(stream: IO[bytes], cmd='ffprobe', **kwargs):
+        """Run ffprobe on an input stream and return a JSON representation of the output.
+
+        Code adopted from ffmpeg-python by Karl Kroening (Apache License 2.0).
+        Copyright 2017 Karl Kroening
+
+        Raises:
+            :class:`ffmpeg.Error`: if ffprobe returns a non-zero exit code,
+                an :class:`Error` is returned with a generic error message.
+                The stderr output can be retrieved by accessing the
+                ``stderr`` property of the exception.
+        """
+        args = [cmd, '-show_format', '-show_streams', '-of', 'json']
+        args += convert_kwargs_to_cmd_line_args(kwargs)
+        args += ["-"]
+
+        p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        assert p.stdin
+        copyfileobj(p.stdin, stream)
+        out, err = p.communicate()
+        if p.returncode != 0:
+            raise ffmpeg.Error('ffprobe', out, err)
+        return json.loads(out.decode('utf-8'))
+
+
+    def gif_conversion(file: IO[bytes]) -> IO[bytes]:
+        """Convert Telegram GIF to real GIF, the NT way."""
+        gif_file = NamedTemporaryFile(suffix='.gif')
+        file.seek(0)
+
+        # Use custom ffprobe command to read from stream
+        metadata = ffprobe(file)
+
+        # Set input/output of ffmpeg to stream
+        stream = ffmpeg.input("pipe:")
+        if metadata['streams'][0]['codec_name'] == 'vp9':
+            stream = ffmpeg.input(file.name, vcodec='libvpx-vp9')
+        if metadata.get('width', 0) > 600:
+            stream = stream.filter("scale", 600, -2)
+        if metadata.get('fps', 0) > 12:
+            stream = stream.filter("fps", 12, round='up')
+        split = (
+            stream
+            .split()
+        )
+        stream_paletteuse = (
+            ffmpeg
+            .filter(
+                [
+                    split[0],
+                    split[1]
+                    .filter(
+                        filter_name='palettegen', 
+                        reserve_transparent='on',
+                    )
+                ],
+                filter_name='paletteuse',
+            )
+        )
+        # Need to specify file format here as no extension hint presents.
+        args = stream_paletteuse.output("pipe:", format="gif").compile()
+        file.seek(0)
+
+        # subprocess.Popen would still try to access the file handle instead of
+        # using standard IO interface. Not sure if that would work on Windows.
+        # Using the most classic buffer and copy via IO interface just to play
+        # safe.
+        p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        assert p.stdin
+        copyfileobj(file, p.stdin)
+        p.stdin.close()
+
+        # Raise exception if error occurs, just like ffmpeg-python.
+        if p.returncode != 0 and p.stderr:
+            err = p.stderr.read().decode()
+            print(err, file=sys.stderr)
+            raise ffmpeg.Error('ffmpeg', "", err)
+
+        assert p.stdout
+        copyfileobj(p.stdout, gif_file)
+        file.close()
+        gif_file.seek(0)
+        return gif_file
+
+else:
+    def gif_conversion(file: IO[bytes]) -> IO[bytes]:
+        """Convert Telegram GIF to real GIF, the non-NT way."""
+        gif_file = NamedTemporaryFile(suffix='.gif')
+        file.seek(0)
+        metadata = ffmpeg.probe(file.name)
+        stream = ffmpeg.input(file.name)
+        # 检查视频编码类型是否为VP9
+        if metadata['streams'][0]['codec_name'] == 'vp9':
+            stream = ffmpeg.input(file.name, vcodec='libvpx-vp9') # 只有这个能保持透明背景
+        if metadata.get('fps', 0) > 12:
+            stream = stream.filter("fps", 12, round='up') # 限制帧率
+        if metadata.get('width', 0) > 600:
+            stream = stream.filter("scale", 600, -2) # 限制宽度
+        split = (
+            stream
+            .split()
+        )
+        stream_paletteuse = (
+            ffmpeg
+            .filter(
+                [
+                    split[0],
+                    split[1]
+                    .filter(
+                        filter_name='palettegen', 
+                        reserve_transparent='on',
+                    )
+                ],
+                filter_name='paletteuse',
+            )
+        )
+        stream_paletteuse.output(gif_file.name).overwrite_output().run() 
+        new_file_size = os.path.getsize(gif_file.name)
+        print(f"file_size: {new_file_size/1024}KB")
+        if new_file_size > 1024 * 1024:
+            # try to use gifsicle lossy compression
+            compress_file = NamedTemporaryFile(suffix='.gif')
+            subprocess.run(["gifsicle", "--resize-method=catrom", "--lossy=100", "-O2", "-o", compress_file.name, gif_file.name], check=True)
+            new_file_size = os.path.getsize(compress_file.name)
+            if new_file_size > 1024 * 1024:
+                scales = [600, 512, 480, 400, 360, 300, 256, 250, 200, 150, 100]
+                scales = [scale for scale in scales if scale < metadata['streams'][0]['width']]
+                scales = sorted(scales, reverse=True)
+                for scale in scales:
+                    subprocess.run(["gifsicle", "--resize-method=catrom",  "--resize-fit", f"{scale}x{scale}", "--lossy=100", "-O2", "-o", compress_file.name, gif_file.name], check=True)
+                    new_file_size = os.path.getsize(compress_file.name)
+                    print(f"new_file_size: {new_file_size/1024}KB after resize to {scale}x{scale}")
+                    if new_file_size < 1024 * 1024:
+                        break
+            gif_file.close()
+            gif_file = compress_file
+        file.close()
+        gif_file.seek(0)
+        return gif_file

--- a/efb_wechat_slave/utils.py
+++ b/efb_wechat_slave/utils.py
@@ -326,55 +326,25 @@ if os.name == "nt":
 else:
     def gif_conversion(file: IO[bytes]) -> IO[bytes]:
         """Convert Telegram GIF to real GIF, the non-NT way."""
-        gif_file = NamedTemporaryFile(suffix='.gif')
         file.seek(0)
-        metadata = ffmpeg.probe(file.name)
-        stream = ffmpeg.input(file.name)
-        # 检查视频编码类型是否为VP9
-        if metadata['streams'][0]['codec_name'] == 'vp9':
-            stream = ffmpeg.input(file.name, vcodec='libvpx-vp9') # 只有这个能保持透明背景
-        if metadata.get('fps', 0) > 12:
-            stream = stream.filter("fps", 12, round='up') # 限制帧率
-        if metadata.get('width', 0) > 600:
-            stream = stream.filter("scale", 600, -2) # 限制宽度
-        split = (
-            stream
-            .split()
-        )
-        stream_paletteuse = (
-            ffmpeg
-            .filter(
-                [
-                    split[0],
-                    split[1]
-                    .filter(
-                        filter_name='palettegen', 
-                        reserve_transparent='on',
-                    )
-                ],
-                filter_name='paletteuse',
-            )
-        )
-        stream_paletteuse.output(gif_file.name).overwrite_output().run() 
-        new_file_size = os.path.getsize(gif_file.name)
+        new_file_size = os.path.getsize(file.name)
         print(f"file_size: {new_file_size/1024}KB")
         if new_file_size > 1024 * 1024:
             # try to use gifsicle lossy compression
             compress_file = NamedTemporaryFile(suffix='.gif')
-            subprocess.run(["gifsicle", "--resize-method=catrom", "--lossy=100", "-O2", "-o", compress_file.name, gif_file.name], check=True)
+            subprocess.run(["gifsicle", "--resize-method=catrom", "--lossy=100", "-O2", "-o", compress_file.name, file.name], check=True)
             new_file_size = os.path.getsize(compress_file.name)
             if new_file_size > 1024 * 1024:
                 scales = [600, 512, 480, 400, 360, 300, 256, 250, 200, 150, 100]
                 scales = [scale for scale in scales if scale < metadata['streams'][0]['width']]
                 scales = sorted(scales, reverse=True)
                 for scale in scales:
-                    subprocess.run(["gifsicle", "--resize-method=catrom",  "--resize-fit", f"{scale}x{scale}", "--lossy=100", "-O2", "-o", compress_file.name, gif_file.name], check=True)
+                    subprocess.run(["gifsicle", "--resize-method=catrom",  "--resize-fit", f"{scale}x{scale}", "--lossy=100", "-O2", "-o", compress_file.name, file.name], check=True)
                     new_file_size = os.path.getsize(compress_file.name)
                     print(f"new_file_size: {new_file_size/1024}KB after resize to {scale}x{scale}")
                     if new_file_size < 1024 * 1024:
                         break
-            gif_file.close()
-            gif_file = compress_file
-        file.close()
-        gif_file.seek(0)
-        return gif_file
+            file.close()
+            file = compress_file
+        file.seek(0)
+        return file


### PR DESCRIPTION
Sending stickers from efb via telegram to WeChat often encounters errors like the one shown below. These errors mostly occur with animated stickers. Other user have such [reports](https://github.com/ehforwarderbot/efb-wechat-slave/issues/55#issuecomment-1207138251) too.

![WeChat error message image](https://github.com/Ovler-Young/efb-telegram-master/assets/44089074/fd4bad79-843d-4eab-a25b-ece7565ae111)

After investigating, I found that these errors are likely due to WeChat's [limit](https://github.com/ehforwarderbot/efb-wechat-slave/issues/55#issuecomment-1207145598) of 1 MB for GIF files used as stickers. Reducing the scale of the GIF can help reduce the file size, which is the main approach I took. 
---
在微信发表情贴图经常会出错,错误信息如下,也有别人[反馈](https://github.com/ehforwarderbot/efb-wechat-slave/issues/55#issuecomment-1207138251)

![WeChat error message image](https://github.com/Ovler-Young/efb-telegram-master/assets/44089074/fd4bad79-843d-4eab-a25b-ece7565ae111)

这类型错误主要是因为微信对表情贴图的GIF文件大小有1M的[限制](https://github.com/ehforwarderbot/efb-wechat-slave/issues/55#issuecomment-1207145598)。这个PR中我主要是通过降低GIF的分辨率来缩小文件,来尽可能避免这种错误。 
